### PR TITLE
Support both html and json output for statuses

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -1,15 +1,29 @@
 class StatusController < ApplicationController
-  def show
-    @pings = Ping.all.sort_by { |x| x.service }
+  before_filter :load_services
 
-    crit = @pings.any? { |x| x.down? and x.critical? }
+  def show
+    respond_to do |f|
+      f.html { render }
+      f.json { render :json => json_status }
+    end
+  end
+
+  private
+
+  def load_services
+    @pings   = Ping.all.sort_by { |x| x.service }
+    critical = @pings.any? { |x| x.down? and x.critical? }
 
     if @pings.empty?
       @status = "unknown"
-    elsif crit
+    elsif critical
       @status = "down"
     else
       @status = @pings.any? { |x| x.down? } ? "partial" : "up"
     end
+  end
+
+  def json_status
+    {:status => @status, :services => @pings}
   end
 end

--- a/app/models/ping.rb
+++ b/app/models/ping.rb
@@ -19,4 +19,13 @@ class Ping < ActiveRecord::Base
     return "unknown" if unknown?
     status
   end
+
+  def as_json(options={})
+    {
+      :name        => service, 
+      :description => description, 
+      :status      => status,
+      :last_update => last_seen
+    }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 RubygemsStatus::Application.routes.draw do
   root :to => 'status#show'
+  get 'status' => 'status#show'
 end


### PR DESCRIPTION
Site now supports status information for both HTML and JSON outputs. I added extra route `/status` that points to the same method. 

JSON will be returned at `/status.json` in the following format:

``` json
{
  "status": "up",
  "services": [{
    "name": "Application",
    "description": "Main application",
    "status": "up",
    "last_update": "2012-10-24T06:05:12Z"
  }]
}
```
