### PR TITLE
Add support for json output for statuses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'sass-rails'
 gem 'coffee-rails'
 gem 'uglifier'
 gem 'rails_12factor'
+gem 'jbuilder'
 
 gem 'rake'
 gem 'mocha', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,9 @@ GEM
     execjs (2.2.1)
     hike (1.2.3)
     i18n (0.6.11)
+    jbuilder (2.0.6)
+      activesupport (>= 3.0.0, < 5)
+      multi_json (~> 1.2)
     jquery-rails (3.1.1)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
@@ -109,6 +112,7 @@ PLATFORMS
 
 DEPENDENCIES
   coffee-rails
+  jbuilder
   jquery-rails
   json
   mocha

--- a/app/views/status/show.json.jbuilder
+++ b/app/views/status/show.json.jbuilder
@@ -1,0 +1,13 @@
+json.status @status
+
+json.services @pings do |ping|
+  json.name        ping.service
+  json.status      ping.state
+  json.description ping.description
+
+  if !ping.unknown?
+    json.last_seen ping.last_seen.iso8601
+  else
+    json.last_seen "unknown"
+  end
+end

--- a/test/integration/status_json_test.rb
+++ b/test/integration/status_json_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class StatusJsonTest < ActionDispatch::IntegrationTest
+  def json_response
+    JSON.parse(response.body)
+  end
+
+  test "Status API: GET / when all services are up" do
+    Ping.create! status: "up", service: "Application", description: "This service is up", last_seen: Time.new(2014, 3, 14, 1, 59, 26).utc
+    Ping.create! status: "up", service: "Core API", description: "This service is up", last_seen: Time.new(2014, 2, 7, 1, 8, 28).utc
+
+    get "/", {}, {"Accept" => "application/json"}
+
+    service = json_response["services"].find { |s| s["name"] == "Core API" }
+
+    assert_match "up", json_response["status"]
+    assert_match "up", json_response["services"][0]["status"]
+    assert_match "This service is up",   json_response["services"][0]["descrption"]
+    assert_match "2014-03-14T08:59:26Z", json_response["services"][0]["last_seen"]
+  end
+
+  test "Status API: GET / when some of the services are down" do
+    Ping.create! status: "down", service: "Application", last_seen: Time.new(2014, 3, 14, 1, 59, 26).utc
+    Ping.create! status: "up", service: "Core API", last_seen: Time.new(2014, 2, 7, 1, 8, 28).utc
+
+    get "/", {}, {"Accept" => "application/json"}
+
+    assert_match "partial", json_response["status"]
+    assert_match "down",    json_response["services"][0]["status"]
+    assert_match "up",      json_response["services"][1]["status"]
+  end
+
+  test "Status API: GET / when all of the services are down" do
+    Ping.create! status: "down", service: "Application", last_seen: Time.new(2014, 3, 14, 1, 59, 26).utc
+    Ping.create! status: "down", service: "Core API", last_seen: Time.new(2014, 2, 7, 1, 8, 28).utc
+
+    get "/", {}, {"Accept" => "application/json"}
+
+    assert_match "down", json_response["status"]
+    assert_match "down", json_response["services"][0]["status"]
+    assert_match "down", json_response["services"][1]["status"]
+  end
+end


### PR DESCRIPTION
There were a couple of pull requests #5 and #7 for this support, but none of them came with tests. This pull request does.

The json schema is the same as #5, but you can put `Accept: application/json` to get json result.

`GET "/" Accept: application/json`:

``` json
{
  "status": "up",
  "services": [
    {
      "name": "Application",
      "description": "Main application",
      "status": "up",
      "last_seen": "2012-10-24T06:05:12Z"
    }
  ]
}
```
