### PR TITLE
git differences after I downloaded code and ran db:migrate

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,15 +9,15 @@
 # from scratch. The latter is a flawed and unsustainable approach (the more migrations
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
-# It's strongly recommended to check this file into your version control system.
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120306045347) do
+ActiveRecord::Schema.define(version: 20120306045347) do
 
-  create_table "pings", :force => true do |t|
+  create_table "pings", force: true do |t|
     t.string   "service"
     t.string   "status"
-    t.datetime "created_at",  :null => false
-    t.datetime "updated_at",  :null => false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.boolean  "critical"
     t.datetime "last_seen"
     t.text     "description"


### PR DESCRIPTION
@dwradcliffe - not sure how we/you want to handle this. I pulled down the code and ran `rake db:migrate`. The schema timestamp is unchanged, but the default values for `created_at` and `updated_at` are different. Was this change in Rails - I think I missed something.

Anyways, I thought it would be good to quickly take care of this.
